### PR TITLE
[cleanup] Remove DNS records pointing to postal or EC2

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -7,74 +7,14 @@ resource "aws_route53_zone" "speakforme-in" {
   }
 }
 
-resource "aws_route53_record" "campaign-a" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "campaign.speakforme.in"
-  type    = "A"
-  ttl     = "300"
-  records = ["34.199.252.2"]
-}
-
-locals {
-  postal-server-ip = "18.211.250.184"
-}
-
-resource "aws_route53_record" "postal-mx-a" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "mx.postal"
-  type    = "A"
-  ttl     = "300"
-  records = ["${local.postal-server-ip}"]
-}
-
-resource "aws_route53_record" "postal-a" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "postal"
-  type    = "A"
-  ttl     = "300"
-  records = ["${local.postal-server-ip}"]
-}
-
-resource "aws_route53_record" "postal-rp-a" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "rp.postal"
-  type    = "A"
-  ttl     = "300"
-  records = ["${local.postal-server-ip}"]
-}
-
-resource "aws_route53_record" "postal-sf-a" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "sf.postal"
-  type    = "A"
-  ttl     = "300"
-  records = ["${local.postal-server-ip}"]
-}
-
-resource "aws_route53_record" "storage-a" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "storage"
-  type    = "A"
-  ttl     = "300"
-  records = ["35.153.240.239"]
-}
-
 resource "aws_route53_record" "speakforme-a" {
   zone_id = "${aws_route53_zone.speakforme-in.id}"
   name    = "speakforme.in"
   type    = "A"
   ttl     = "300"
+
+  // Netlify
   records = ["104.198.14.52"]
-}
-
-// CNAME Records
-
-resource "aws_route53_record" "beta-cname" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "beta"
-  type    = "CNAME"
-  ttl     = "1800"
-  records = ["speakforme.github.io."]
 }
 
 resource "aws_route53_record" "netlify-cname" {
@@ -83,22 +23,6 @@ resource "aws_route53_record" "netlify-cname" {
   type    = "CNAME"
   ttl     = "1800"
   records = ["speakforme.netlify.com."]
-}
-
-resource "aws_route53_record" "psrp-email-cname" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "psrp.email"
-  type    = "CNAME"
-  ttl     = "1800"
-  records = ["rp.postal.speakforme.in."]
-}
-
-resource "aws_route53_record" "psrp-cname" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "psrp"
-  type    = "CNAME"
-  ttl     = "1800"
-  records = ["rp.postal.speakforme.in."]
 }
 
 resource "aws_route53_record" "www" {
@@ -118,27 +42,5 @@ resource "aws_route53_record" "email-mx" {
 
   records = [
     "10 inbound-smtp.eu-west-1.amazonaws.com.",
-  ]
-}
-
-resource "aws_route53_record" "routes-mx" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "routes"
-  type    = "MX"
-  ttl     = "1800"
-
-  records = [
-    "10 mx.postal.speakforme.in.",
-  ]
-}
-
-resource "aws_route53_record" "speakforme-mx" {
-  zone_id = "${aws_route53_zone.speakforme-in.id}"
-  name    = "speakforme.in"
-  type    = "MX"
-  ttl     = "1800"
-
-  records = [
-    "10 mx.postal.speakforme.in.",
   ]
 }


### PR DESCRIPTION
Plan:

It removes a lot of DNS entries pointing to dead or old infrastructure.

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  - aws_route53_record.beta-cname

  - aws_route53_record.campaign-a

  - aws_route53_record.postal-a

  - aws_route53_record.postal-mx-a

  - aws_route53_record.postal-rp-a

  - aws_route53_record.postal-sf-a

  - aws_route53_record.psrp-cname

  - aws_route53_record.psrp-email-cname

  - aws_route53_record.routes-mx

  - aws_route53_record.speakforme-mx

  - aws_route53_record.storage-a


Plan: 0 to add, 0 to change, 11 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```